### PR TITLE
Use SSH_AUTH_SOCK and some debug prints when gpg agent socket fails to connect

### DIFF
--- a/scd.c
+++ b/scd.c
@@ -44,12 +44,15 @@ static gpg_error_t find_gpg_socket(char *buf, size_t len)
 	char *tmp, *t, *ext = NULL;
 	tmp = getenv("SSH_AUTH_SOCK");
 	if (tmp) {
-		ext = "/S.gpg-agent.ssh";
-		if (strlen(tmp) + strlen(ext) + 1 > len)
-			return 1;
-		t = stpcpy(buf, tmp);
-		stpcpy(t, ext);
-		return 0;
+		ext = ".ssh";
+		if (strlen(tmp) + sizeof(char) > len){
+			return 1;}
+		strncpy(buf, tmp, len);
+		t = strstr(buf, ext);
+		if (t != NULL){
+			*t = '\0';
+			return 0;
+		}
 	}
 	tmp = getenv("GPG_AGENT_INFO");
 	if (tmp) {

--- a/scd.c
+++ b/scd.c
@@ -42,6 +42,15 @@ struct sec_signature {
 static gpg_error_t find_gpg_socket(char *buf, size_t len)
 {
 	char *tmp, *t, *ext = NULL;
+	tmp = getenv("SSH_AUTH_SOCK");
+	if (tmp) {
+		ext = "/S.gpg-agent.ssh";
+		if (strlen(tmp) + strlen(ext) + 1 > len)
+			return 1;
+		t = stpcpy(buf, tmp);
+		stpcpy(t, ext);
+		return 0;
+	}
 	tmp = getenv("GPG_AGENT_INFO");
 	if (tmp) {
 		t = strchr(tmp, ':');

--- a/scd.c
+++ b/scd.c
@@ -134,7 +134,10 @@ gpg_error_t scd_agent_connect(assuan_context_t *ctx)
 	if (*ctx != NULL) { return 0; }
 
 	err = find_gpg_socket(gpg_agent_socket_name, 1024);
-	if (err) { return err; }
+	if (err) { 
+		SDEBUG("Could not find agent path, check env. variables");
+		return err; 
+	}
 
 	err = assuan_new(ctx);
 	if (err) { return err; }
@@ -143,6 +146,7 @@ gpg_error_t scd_agent_connect(assuan_context_t *ctx)
 	if (err) {
 		assuan_release(*ctx);
 		*ctx = NULL;
+		SDEBUG("Could not connect to agent via socket: '%s'", gpg_agent_socket_name);
 		return err;
 	}
 


### PR DESCRIPTION
With GnuPG 2.1 the need of GPG_AGENT_INFO has been completely removed and the variable is ignored.[1]

Was having troubles using the library and I thought some debug outputs would've help a lot.

[1] https://www.gnupg.org/faq/whats-new-in-2.1.html
