### PR TITLE
Fix segfault in C_GetAttributeValue

### DIFF
--- a/sec.c
+++ b/sec.c
@@ -132,10 +132,10 @@ static void sec_convert_cert3_to_attribute_list()
 		if (a1serial) {
 			BIGNUM *bn = ASN1_INTEGER_to_BN(a1serial, NULL);
 			if (bn) {
-				char *serial = BN_bn2dec(bn);
+				serial = (unsigned char *)BN_bn2dec(bn);
 				BN_free(bn);
 				if (serial) {
-					serial_len = strlen(serial);
+					serial_len = strlen((const char *)serial);
 				}
 			}
 		}


### PR DESCRIPTION
sec_convert_cert3_to_attribute_list() previously defined serial in two
different scopes - first as a CK_BYTE*, and later on as a char*. This
led to serial_len being set to a valid length, but the CK_BYTE* remained
NULL when processed by C_GetAttributeValue().

On my system this was causing Chrome/Firefox to segfault at
pkcs11-impl.c:667 during the memcpy, due to pTmp->pValue being NULL.

This commit removes the second definition of serial and casts the
existing CK_BYTE* where necessary.

Signed-off-by: Matt Merhar <mattmerhar@protonmail.com>